### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test: impulse.o
 	gcc -c src/test-impulse.c -o $(BUILD_DIR)/test/test-impulse.o
 	gcc -L$(BUILD_DIR)/test/ -lfftw3 -lpulse\
 		$(BUILD_DIR)/impulse/impulse.o $(BUILD_DIR)/test/test-impulse.o\
-		-o $(BUILD_DIR)/test/test-impulse
+		-o $(BUILD_DIR)/test/test-impulse -lm
 
 impulse.o:
 	gcc -pthread -Wall -fPIC -c src/impulse.c -o $(BUILD_DIR)/impulse/impulse.o


### PR DESCRIPTION
I had to add this line for the build to complete successfully.  Otherwise I got the following error:

```
gcc -Lbuild/`uname -m`/test/ -lfftw3 -lpulse\
    build/`uname -m`/impulse/impulse.o build/`uname -m`/test/test-impulse.o\
    -o build/`uname -m`/test/test-impulse
/usr/bin/ld: build/armv6l/impulse/impulse.o: undefined reference to symbol 'sqrt@@GLIBC_2.4'
//lib/arm-linux-gnueabihf/libm.so.6: error adding symbols: DSO missing from command line
collect2: ld returned 1 exit status
Makefile:22: recipe for target 'test' failed
make: *** [test] Error 1
```
